### PR TITLE
add ifdef for include simple lvgl.h

### DIFF
--- a/examples/ui.h
+++ b/examples/ui.h
@@ -14,7 +14,11 @@ extern "C" {
  *********************/
 
 /* Include all the UI libraries */
-#include "lvgl/lvgl.h"
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+    #include "lvgl.h"
+#else
+    #include "lvgl/lvgl.h"
+#endif
 #include "examples.h"
 
 /*********************


### PR DESCRIPTION
Here is the only place in the Editor examples project that has only #include "lvgl/lvgl.h" and not the include simple option. Shouldn't it have the include simple ifdef as well?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add LV_LVGL_H_INCLUDE_SIMPLE guard to examples/ui.h to support both include styles: lvgl.h when simple include is enabled, otherwise lvgl/lvgl.h. This fixes builds that define LV_LVGL_H_INCLUDE_SIMPLE and aligns the file with the rest of the project.

<!-- End of auto-generated description by cubic. -->

