### PR TITLE
docs(README.md):  remove reference to future v0.2 video

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We believe designers should work freely in creative tools like Figma. LVGL’s E
 
 ---
 
-This video provides a step-by-step guide to all supported features. A new video for v0.2 is coming soon.  
+This video provides a step-by-step guide to all supported features.
 
 [![image](https://github.com/user-attachments/assets/2c72c3c9-44fa-4ae4-8616-867e2efe3209)](https://www.youtube.com/embed/TghXiRl6LT4?si=Gd-_pc5fGmTEaOyu)
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the outdated note about an upcoming v0.2 demo video in the README to avoid confusion. The existing tutorial video link remains unchanged.

<!-- End of auto-generated description by cubic. -->

