### PR TITLE
Add stale issue automation

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * *' # Runs daily
 
+  workflow_dispatch:
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,15 @@
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          stale-issue-message: 'This issue has been inactive for 30 days. If it is still important, please add a comment or we will consider it resolved.'
+          days-before-close: -1   # Never close, just comment


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a daily GitHub Action to mark inactive issues and PRs as stale after 30 days and prompt follow-up, without auto-closing anything.

- **New Features**
  - Runs nightly at 00:00 UTC using actions/stale@v9 and supports manual runs via workflow_dispatch.
  - Marks items stale after 30 days and posts a reminder comment; never closes.

<sup>Written for commit 2a1549c3203ed184832eef2ddf1afba5445ca114. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



