### PR TITLE
Flatten meta.json pages arrays to string-only entries

### DIFF
--- a/docs/features/meta.json
+++ b/docs/features/meta.json
@@ -3,7 +3,7 @@
   "pages": [
     "index",
     "data-binding",
-    { "slug": "ui-testing", "title": "UI Testing" },
+    "ui-testing",
     "language-translations"
   ]
 }

--- a/docs/integration/meta.json
+++ b/docs/integration/meta.json
@@ -3,9 +3,9 @@
   "pages": [
     "index",
     "using-exported-c-code",
-    { "slug": "loading-xml-files", "title": "Loading XML Files" },
+    "loading-xml-files",
     "renesas",
-    { "slug": "arduino-ide", "title": "Arduino IDE" },
-    { "slug": "zephyr-rtos", "title": "Zephyr RTOS" }
+    "arduino-ide",
+    "zephyr-rtos"
   ]
 }

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -1,11 +1,11 @@
 {
   "pages": [
-    { "slug": "introduction", "title": "Introduction" },
+    "introduction",
     "learn-by-examples",
     "editor",
     "xml-overview",
     "integration",
-    { "slug": "ui-elements", "title": "UI Elements" },
+    "ui-elements",
     "assets",
     "features",
     "tools"

--- a/docs/tools/meta.json
+++ b/docs/tools/meta.json
@@ -2,7 +2,7 @@
   "title": "Tools",
   "pages": [
     "index",
-    { "slug": "cli", "title": "CLI" },
+    "cli",
     "online-share",
     "figma-integration"
   ]

--- a/docs/ui-elements/meta.json
+++ b/docs/ui-elements/meta.json
@@ -6,9 +6,9 @@
     "widgets",
     "screens",
     "animations",
-    { "slug": "api", "title": "API" },
+    "api",
     "constants",
-    { "slug": "events-in-xml", "title": "Events in XML" },
+    "events-in-xml",
     "preview",
     "styles",
     "view"

--- a/docs/xml-overview/meta.json
+++ b/docs/xml-overview/meta.json
@@ -4,6 +4,6 @@
     "index",
     "overview",
     "syntax",
-    { "slug": "xml-license", "title": "XML License" }
+    "xml-license"
   ]
 }


### PR DESCRIPTION
fumadocs-mdx rejects `{ "slug": "x", "title": "Y" }` entries in `meta.json` pages arrays with `Invalid input: expected string, received object`. Converted all 10 object entries across 6 `meta.json` files under `docs/` to plain string slugs. Sidebar labels now resolve from each page's MDX frontmatter `title:`.

Files changed: `docs/meta.json`, `docs/tools/meta.json`, `docs/integration/meta.json`, `docs/features/meta.json`, `docs/xml-overview/meta.json`, `docs/ui-elements/meta.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened all `meta.json` pages arrays to string slugs to match `fumadocs-mdx` requirements. This fixes the docs build and shifts sidebar labels to MDX frontmatter titles.

- **Bug Fixes**
  - Resolved "Invalid input: expected string, received object" by removing `{ slug, title }` entries.
  - Updated 6 files under `docs/`; replaced 10 objects with plain string slugs.

<sup>Written for commit 06a725700e16ea922b6e1ef45490ccb15574dcde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

