### PR TITLE
docs: strip examples/ prefix from LvglExample path attributes

### DIFF
--- a/docs/built_in_widgets/lv_arc.mdx
+++ b/docs/built_in_widgets/lv_arc.mdx
@@ -9,7 +9,7 @@ The Arc draws a background ring and a foreground indicator arc. The indicator ca
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/arc).
 
-<LvglExample name="lv_example_arc" path="examples/screens/lv_example_arc" />
+<LvglExample name="lv_example_arc" path="screens/lv_example_arc" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_arc.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_bar.mdx
+++ b/docs/built_in_widgets/lv_bar.mdx
@@ -9,7 +9,7 @@ The Bar has a background and an indicator whose length represents the current va
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/bar).
 
-<LvglExample name="lv_example_bar" path="examples/screens/lv_example_bar" />
+<LvglExample name="lv_example_bar" path="screens/lv_example_bar" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_bar.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_button.mdx
+++ b/docs/built_in_widgets/lv_button.mdx
@@ -9,7 +9,7 @@ A Button is a clickable [Base Widget](./lv_obj) with defaults tuned for its role
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/button).
 
-<LvglExample name="lv_example_button" path="examples/screens/lv_example_button" />
+<LvglExample name="lv_example_button" path="screens/lv_example_button" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_button.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_buttonmatrix.mdx
+++ b/docs/built_in_widgets/lv_buttonmatrix.mdx
@@ -9,7 +9,7 @@ The Button Matrix displays many buttons arranged in rows and columns from a sing
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/buttonmatrix).
 
-<LvglExample name="lv_example_buttonmatrix" path="examples/screens/lv_example_buttonmatrix" />
+<LvglExample name="lv_example_buttonmatrix" path="screens/lv_example_buttonmatrix" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_buttonmatrix.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_calendar.mdx
+++ b/docs/built_in_widgets/lv_calendar.mdx
@@ -9,7 +9,7 @@ The Calendar shows the days of a month in a 7×7 grid with weekday names, highli
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/calendar).
 
-<LvglExample name="lv_example_calendar" path="examples/screens/lv_example_calendar" />
+<LvglExample name="lv_example_calendar" path="screens/lv_example_calendar" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_calendar.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_chart.mdx
+++ b/docs/built_in_widgets/lv_chart.mdx
@@ -9,7 +9,7 @@ The Chart visualizes one or more data series as lines, bars or scatter points. I
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/chart).
 
-<LvglExample name="lv_example_chart" path="examples/screens/lv_example_chart" />
+<LvglExample name="lv_example_chart" path="screens/lv_example_chart" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_chart.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_checkbox.mdx
+++ b/docs/built_in_widgets/lv_checkbox.mdx
@@ -9,7 +9,7 @@ The Checkbox combines a tick box with a label. Clicking it toggles the checked s
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/checkbox).
 
-<LvglExample name="lv_example_checkbox" path="examples/screens/lv_example_checkbox" />
+<LvglExample name="lv_example_checkbox" path="screens/lv_example_checkbox" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_checkbox.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_dropdown.mdx
+++ b/docs/built_in_widgets/lv_dropdown.mdx
@@ -9,7 +9,7 @@ The Drop-down List shows a single selected value and, when activated, opens a li
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/dropdown).
 
-<LvglExample name="lv_example_dropdown" path="examples/screens/lv_example_dropdown" />
+<LvglExample name="lv_example_dropdown" path="screens/lv_example_dropdown" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_dropdown.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_image.mdx
+++ b/docs/built_in_widgets/lv_image.mdx
@@ -9,7 +9,7 @@ The Image widget displays images from compiled-in arrays or from files. It can r
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/image).
 
-<LvglExample name="lv_example_image" path="examples/screens/lv_example_image" />
+<LvglExample name="lv_example_image" path="screens/lv_example_image" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_image.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_imagebutton.mdx
+++ b/docs/built_in_widgets/lv_imagebutton.mdx
@@ -9,7 +9,7 @@ The Image Button behaves like a [Button](./lv_button) but draws user-supplied im
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/imagebutton).
 
-<LvglExample name="lv_example_imagebutton" path="examples/screens/lv_example_imagebutton" />
+<LvglExample name="lv_example_imagebutton" path="screens/lv_example_imagebutton" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_imagebutton.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_keyboard.mdx
+++ b/docs/built_in_widgets/lv_keyboard.mdx
@@ -9,7 +9,7 @@ The Keyboard is a specialized [Button Matrix](./lv_buttonmatrix) with predefined
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/keyboard).
 
-<LvglExample name="lv_example_keyboard" path="examples/screens/lv_example_keyboard" />
+<LvglExample name="lv_example_keyboard" path="screens/lv_example_keyboard" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_keyboard.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_label.mdx
+++ b/docs/built_in_widgets/lv_label.mdx
@@ -9,7 +9,7 @@ The Label is the widget used to display text. It supports line wrapping, several
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/label).
 
-<LvglExample name="lv_example_label" path="examples/screens/lv_example_label" />
+<LvglExample name="lv_example_label" path="screens/lv_example_label" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_label.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_led.mdx
+++ b/docs/built_in_widgets/lv_led.mdx
@@ -9,7 +9,7 @@ The LED is a rectangle or circle whose brightness can be adjusted to simulate a 
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/led).
 
-<LvglExample name="lv_example_led" path="examples/screens/lv_example_led" />
+<LvglExample name="lv_example_led" path="screens/lv_example_led" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_led.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_obj.mdx
+++ b/docs/built_in_widgets/lv_obj.mdx
@@ -11,7 +11,7 @@ In XML it doubles as the generic container you reach for when composing layouts 
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/base_widget).
 
-<LvglExample name="lv_example_obj" path="examples/screens/lv_example_obj" />
+<LvglExample name="lv_example_obj" path="screens/lv_example_obj" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_obj.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_qrcode.mdx
+++ b/docs/built_in_widgets/lv_qrcode.mdx
@@ -9,7 +9,7 @@ The QR Code widget generates and displays a QR-code bitmap from a string using L
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/libs/qrcode).
 
-<LvglExample name="lv_example_qrcode" path="examples/screens/lv_example_qrcode" />
+<LvglExample name="lv_example_qrcode" path="screens/lv_example_qrcode" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_qrcode.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_roller.mdx
+++ b/docs/built_in_widgets/lv_roller.mdx
@@ -9,7 +9,7 @@ The Roller lets the user pick one item from a list by scrolling it like a wheel.
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/roller).
 
-<LvglExample name="lv_example_roller" path="examples/screens/lv_example_roller" />
+<LvglExample name="lv_example_roller" path="screens/lv_example_roller" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_roller.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_scale.mdx
+++ b/docs/built_in_widgets/lv_scale.mdx
@@ -9,7 +9,7 @@ The Scale draws a linear or circular scale with a configurable range, tick count
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/scale).
 
-<LvglExample name="lv_example_scale" path="examples/screens/lv_example_scale" />
+<LvglExample name="lv_example_scale" path="screens/lv_example_scale" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_scale.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_slider.mdx
+++ b/docs/built_in_widgets/lv_slider.mdx
@@ -9,7 +9,7 @@ The Slider is a [Bar](./lv_bar) with a draggable knob. It can be horizontal or v
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/slider).
 
-<LvglExample name="lv_example_slider" path="examples/screens/lv_example_slider" />
+<LvglExample name="lv_example_slider" path="screens/lv_example_slider" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_slider.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_spangroup.mdx
+++ b/docs/built_in_widgets/lv_spangroup.mdx
@@ -9,7 +9,7 @@ The Span Group displays rich text built from multiple spans, each with its own t
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/spangroup).
 
-<LvglExample name="lv_example_spangroup" path="examples/screens/lv_example_spangroup" />
+<LvglExample name="lv_example_spangroup" path="screens/lv_example_spangroup" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_spangroup.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_spinbox.mdx
+++ b/docs/built_in_widgets/lv_spinbox.mdx
@@ -9,7 +9,7 @@ The Spinbox is a numeric editor built on a [Text Area](./lv_textarea). It shows 
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/spinbox).
 
-<LvglExample name="lv_example_spinbox" path="examples/screens/lv_example_spinbox" />
+<LvglExample name="lv_example_spinbox" path="screens/lv_example_spinbox" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_spinbox.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_spinner.mdx
+++ b/docs/built_in_widgets/lv_spinner.mdx
@@ -9,7 +9,7 @@ The Spinner shows a continuously rotating arc over a ring to indicate that an ac
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/spinner).
 
-<LvglExample name="lv_example_spinner" path="examples/screens/lv_example_spinner" />
+<LvglExample name="lv_example_spinner" path="screens/lv_example_spinner" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_spinner.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_switch.mdx
+++ b/docs/built_in_widgets/lv_switch.mdx
@@ -9,7 +9,7 @@ The Switch looks like a small slider and displays — and optionally toggles —
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/switch).
 
-<LvglExample name="lv_example_switch" path="examples/screens/lv_example_switch" />
+<LvglExample name="lv_example_switch" path="screens/lv_example_switch" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_switch.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_table.mdx
+++ b/docs/built_in_widgets/lv_table.mdx
@@ -9,7 +9,7 @@ The Table displays text in rows, columns and cells. Only the cell text is stored
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/table).
 
-<LvglExample name="lv_example_table" path="examples/screens/lv_example_table" />
+<LvglExample name="lv_example_table" path="screens/lv_example_table" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_table.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_tabview.mdx
+++ b/docs/built_in_widgets/lv_tabview.mdx
@@ -9,7 +9,7 @@ The Tab View organizes content into tabs with a tab bar. Each tab is a container
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/tabview).
 
-<LvglExample name="lv_example_tabview" path="examples/screens/lv_example_tabview" />
+<LvglExample name="lv_example_tabview" path="screens/lv_example_tabview" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_tabview.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 

--- a/docs/built_in_widgets/lv_textarea.mdx
+++ b/docs/built_in_widgets/lv_textarea.mdx
@@ -9,7 +9,7 @@ The Text Area is an editable text input with a cursor. It wraps long lines, can 
 
 Learn more in the [LVGL Open documentation](https://lvgl.io/docs/open/widgets/textarea).
 
-<LvglExample name="lv_example_textarea" path="examples/screens/lv_example_textarea" />
+<LvglExample name="lv_example_textarea" path="screens/lv_example_textarea" />
 
 {/* @generated from lv_xml/xmls/widgets/lv_textarea.xml — do not edit below this line; re-run docs/scripts/gen_widget_api.ts instead. */}
 


### PR DESCRIPTION
Strips the `examples/` prefix from the `path` attribute of every `<LvglExample>` tag across the built-in widget docs.

`path="examples/screens/..."` → `path="screens/..."`

Affects 25 `.mdx` files under `docs/built_in_widgets/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `examples/` prefix from the `path` attribute in all `<LvglExample>` tags in the built-in widget docs to match the component’s expected paths. Example: `path="examples/screens/..."` → `path="screens/..."` (25 files under `docs/built_in_widgets/`).

<sup>Written for commit d6079d516b2337eaac3ce98a586aca55301c2974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lvgl_editor/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

